### PR TITLE
adding default document dir and default return value

### DIFF
--- a/src/importer.js
+++ b/src/importer.js
@@ -27,8 +27,8 @@ var app = new Vue({
     importAccounts: {},
     importTransactions: {},
     accountMatch: {},
-    budgets: getBudgets().budgets,
-    selectedBudget: getBudgets().selectedBudget
+    budgets: getBudgets() ? getBudgets().budgets : [],
+    selectedBudget: getBudgets() ? getBudgets().selectedBudget : {}
   },
   computed: {
     selectedAccountOb() {
@@ -209,10 +209,12 @@ function getBudgets() {
     let path = os.homedir() + '/Library/Application Support/Actual/global-store.json'
     let actualSettings = JSON.parse(fs.readFileSync(path))
     this.selectedBudget = actualSettings['lastBudget']
-    this.budgets = fs.readdirSync(actualSettings['document-dir'], { withFileTypes: true })
+    let documentDir = actualSettings['document-dir'] || os.homedir() + '/Documents/Actual';
+    this.budgets = fs.readdirSync(documentDir, { withFileTypes: true })
       .filter(dirent => dirent.isDirectory()).map(dirent => dirent.name)
   } catch (error) {
     console.error(error)
+    return {selectedBudget: '', budgets: []};
   }
   return {selectedBudget, budgets}
 }


### PR DESCRIPTION
node version of electron does not support null aware operator, ternary is used instead.
The function should either throw the error or return defaults. This commit fixes #5 adds defaults to getBudgets() and checks for undefined to prevent crashing the whole app. Either defaults or null checking is required.